### PR TITLE
Format kubectl explain output to avoid incorrect line breaks in hover

### DIFF
--- a/explainer.js
+++ b/explainer.js
@@ -1,0 +1,277 @@
+
+function formatExplain(rawText) {
+    if (!rawText) {
+        return rawText;
+    }
+
+    var lines = rawText.replace(/\r\n/g, '\n').split('\n');
+
+    if (rawText.startsWith('FIELD')) {
+        return formatField(lines);
+    }
+
+    if (rawText.startsWith('DESCRIPTION')) {
+        return formatDescription(lines);
+    }
+
+    if (rawText.startsWith('RESOURCE')) {
+        return formatResource(lines);
+    }
+
+    return {
+        'language' : "json",
+        'value' : rawText
+    };
+}
+
+function formatField(lines) {
+    /*
+    source:
+
+    FIELD: name <type>
+
+    DESCRIPTION:
+        first line
+        second line
+    
+    desired output:
+
+    **FIELD:** name <type>
+
+    **DESCRIPTION:**
+    first line
+    second line
+    */
+
+    var formattedLines = lines.map(function(line) {
+        var formatted = emboldenPrefix(line);
+        formatted = removeLeading(formatted);
+        return formatted;
+    }, this);
+
+    return formattedLines.join('\n')
+}
+
+function formatDescription(lines) {
+    /*
+    source:
+
+    DESCRIPTION:
+    first line
+    second line
+
+    FIELDS:
+        field1 <type>
+        first line
+        second line
+    
+        field2 <type>
+        first line
+        second line
+    
+    desired output:
+
+    **DESCRIPTION:**
+    first line
+    second line
+
+    **FIELDS:**
+
+    **field1** <type>
+    
+    first line
+    second line
+
+    **field2** <type>
+    
+    first line
+    second line
+    */
+
+    var parserState = 'init';
+    var formattedLines = [];
+
+    while (lines.length > 0) {
+        var line = lines.shift();
+        switch (parserState) {
+            case 'init':
+                var formatted = emboldenPrefix(line);
+                formattedLines.push(formatted);
+                if (formatted.startsWith('**FIELD')) {
+                    formattedLines.push("");
+                    parserState = 'fields-none';
+                }
+                break;
+            case 'fields-none':
+                var formatted = removeLeading(line);
+                formatted = emboldenFieldName(formatted);
+                formattedLines.push(formatted);
+                if (formatted.startsWith('**')) {
+                    parserState = 'field-first';
+                }
+                break;
+            case 'field-first':
+                if (line.length == 0) {
+                    break;
+                }
+                var formatted = removeLeading(line);
+                formattedLines.push("");
+                formattedLines.push(formatted);
+                parserState = 'field-rest';
+                break;
+            case 'field-rest':
+                if (line.length == 0) {
+                    parserState = 'fields-none';
+                    formattedLines.push(line);
+                    break;
+                }
+                var formatted = removeLeading(line);
+                formattedLines.push(formatted);
+                break;
+        }
+    }
+
+    return formattedLines.join('\n');
+}
+
+function formatResource(lines) {
+    /*
+    source:
+
+    RESOURCE: name <type>
+
+    DESCRIPTION:
+         first summary line
+         second summary line
+
+        first line
+        second line
+
+    FIELDS:
+       field1 <type>
+         first line
+         second line
+    
+       field2 <type>
+         first line
+         second line
+    
+    desired output:
+
+    **RESOURCE:** name <type>
+
+    **DESCRIPTION:**
+    first summary line
+    second summary line
+
+    first line
+    second line
+
+    **FIELDS:**
+
+    **field1** <type>
+    
+    first line
+    second line
+
+    **field2** <type>
+    
+    first line
+    second line
+    */
+
+    var parserState = 'init';
+    var formattedLines = [];
+
+    while (lines.length > 0) {
+        var line = lines.shift();
+        switch (parserState) {
+            case 'init':
+                var formatted = emboldenPrefix(line);
+                formattedLines.push(formatted);
+                if (formatted.startsWith('**DESCRIPTION')) {
+                    parserState = 'description-body';
+                }
+                if (formatted.startsWith('**FIELD')) {
+                    formattedLines.push("");
+                    parserState = 'fields-none';
+                }
+                break;
+            case 'description-body':
+                var formatted = emboldenPrefix(line);
+                formatted = removeLeading(formatted);
+                formattedLines.push(formatted);
+                if (formatted.startsWith('**FIELD')) {
+                    formattedLines.push("");
+                    parserState = 'fields-none';
+                }
+                break;
+            case 'fields-none':
+                var formatted = removeLeading(line);
+                formatted = emboldenFieldName(formatted);
+                formattedLines.push(formatted);
+                if (formatted.startsWith('**')) {
+                    parserState = 'field-first';
+                }
+                break;
+            case 'field-first':
+                if (line.length == 0) {
+                    break;
+                }
+                var formatted = removeLeading(line);
+                formattedLines.push("");
+                formattedLines.push(formatted);
+                parserState = 'field-rest';
+                break;
+            case 'field-rest':
+                if (line.length == 0) {
+                    parserState = 'fields-none';
+                    formattedLines.push(line);
+                    break;
+                }
+                var formatted = removeLeading(line);
+                formattedLines.push(formatted);
+                break;
+        }
+    }
+
+    return formattedLines.join('\n');
+}
+
+function emboldenPrefix(line) {
+    if (!line) {
+        return line;
+    }
+    var prefixes = ['FIELD:','FIELDS:','DESCRIPTION:','RESOURCE:'];
+    prefixes.forEach(function(prefix) {
+        if (line.startsWith(prefix)) {
+            line = '**' + prefix + '**' + line.substring(prefix.length);
+        }
+    });
+    return line;
+}
+
+function emboldenFieldName(line) {
+    if (!line) {
+        return line;
+    }
+    var parse = line.match(/^(\w+)\s+\<(\[\])?\w+\>(\s+-required-)?$/);
+    if (parse) {
+        line = '**' + parse[1] + '**' + line.substring(parse[1].length)
+        if (parse[3]) {
+            line = line.replace('-required-', '**[required]**')
+        }
+    }
+    return line;
+}
+
+function removeLeading(line) {
+    if (!line) {
+        return line;
+    }
+    return line.replace(/^\s+/, '')
+}
+
+module.exports = {
+    formatExplain: formatExplain
+}

--- a/extension.js
+++ b/extension.js
@@ -12,6 +12,9 @@ var yaml = require('js-yaml');
 var dockerfileParse = require('dockerfile-parse');
 var shellLib = null;
 
+// Internal dependencies
+var explainer = require('./explainer');
+
 function shell() {
     if (shellLib == null) {
         shellLib = require('shelljs');
@@ -134,10 +137,7 @@ function provideHover(document, position, token) {
     return {
         'then': function (fn) {
             explain(obj, field, function (msg) {
-                fn(new vscode.Hover({
-                    'language': 'json',
-                    'value': msg
-                }));
+                fn(new vscode.Hover(explainer.formatExplain(msg)));
             });
         }
     };

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -11,14 +11,31 @@ var assert = require('assert');
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 var vscode = require('vscode');
-var myExtension = require('../extension');
+var extension = require('../extension');
+var explainer = require('../explainer');
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite("Extension Tests", function() {
+    test("Fields are transformed correctly", function() {
+        assert.equal("**FIELD:** apiVersion", explainer.formatExplain("FIELD: apiVersion"));
+        assert.equal("**FIELD:** apiVersion\n\n**DESCRIPTION:**\nThe version\nof the API", explainer.formatExplain("FIELD: apiVersion\n\nDESCRIPTION:\n    The version\n    of the API"));
+    });
 
-    // Defines a Mocha unit test
-    test("Something 1", function() {
-        assert.equal(-1, [1, 2, 3].indexOf(5));
-        assert.equal(-1, [1, 2, 3].indexOf(0));
+    test("Descriptions are transformed correctly", function() {
+        assert.equal("**DESCRIPTION:**\nKind does thing", explainer.formatExplain("DESCRIPTION:\nKind does thing"));
+        assert.equal("**DESCRIPTION:**\nKind does thing\n\n**FIELDS:**\n\n**apiVersion** <string>\n\nThe version\nof the API", explainer.formatExplain("DESCRIPTION:\nKind does thing\n\nFIELDS:\n  apiVersion <string>\n    The version\n    of the API"));
+        assert.equal("**DESCRIPTION:**\nKind does\nthing\n\n**FIELDS:**\n\n**apiVersion** <string>\n\nThe version\nof the API\n\n**kind** <string>\n\nKind is kind", explainer.formatExplain("DESCRIPTION:\nKind does\nthing\n\nFIELDS:\n  apiVersion <string>\n    The version\n    of the API\n\n  kind <string>\n    Kind is kind"));
+    });
+
+    test("Resources are transformed correctly", function() {
+        assert.equal("**RESOURCE:** spec <object>\n\n**DESCRIPTION:**\nThis is\na description\n\nAnd this is a less indented\npart of the description\n\n**FIELDS:**\n\n**apiVersion** <string>\n\nThe version\nof the API\n\n**volumes** <[]object>\n\nVolumes are voluminous", explainer.formatExplain("RESOURCE: spec <object>\n\nDESCRIPTION:\n     This is\n     a description\n\n    And this is a less indented\n    part of the description\n\nFIELDS:\n   apiVersion <string>\n     The version\n     of the API\n\n   volumes <[]object>\n     Volumes are voluminous"));
+    });
+
+    test("Windows line breaks are handled correctly", function() {
+        assert.equal("**RESOURCE:** spec <object>\n\n**DESCRIPTION:**\nThis is\na description\n\nAnd this is a less indented\npart of the description\n\n**FIELDS:**\n\n**apiVersion** <string>\n\nThe version\nof the API\n\n**volumes** <[]object>\n\nVolumes are voluminous", explainer.formatExplain("RESOURCE: spec <object>\r\n\r\nDESCRIPTION:\r\n     This is\r\n     a description\r\n\r\n    And this is a less indented\r\n    part of the description\r\n\r\nFIELDS:\r\n   apiVersion <string>\r\n     The version\r\n     of the API\r\n\r\n   volumes <[]object>\r\n     Volumes are voluminous"));
+    });
+
+    test("Required fields are emphasised", function() {
+        assert.equal("**RESOURCE:** spec <object>\n\n**DESCRIPTION:**\nFoo\n\n**FIELDS:**\n\n**containers** <[]Object>  **[required]**\n\nSome containers", explainer.formatExplain("RESOURCE: spec <object>\n\nDESCRIPTION:\n     Foo\n\nFIELDS:\n   containers <[]Object>  -required-\n     Some containers"));
     });
 });


### PR DESCRIPTION
The hovers produced by the Kubernetes Explain command contain mid-word line breaks, which also makes the indents disruptive. This PR formats the hovers to make the text read more continuously.