### PR TITLE
Meaningful error if image name cannot be determined

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -532,6 +532,10 @@ function findNameAndImage() {
 };
 
 function _findNameAndImageInternal(fn) {
+    if (vscode.workspace.rootPath === undefined) {
+        vscode.window.showErrorMessage("This command requires an open folder.");
+        return;
+    }
     var name = path.basename(vscode.workspace.rootPath);
     findVersion().then(function (version) {
         var image = name + ":" + version;

--- a/extension.js
+++ b/extension.js
@@ -565,12 +565,14 @@ function buildPushThenExec(fn) {
                         vscode.window.showInformationMessage(image + ' pushed.');
                         fn(name, image);
                     } else {
-                        vscode.window.showErrorMessage('Image push failed.');
+                        vscode.window.showErrorMessage('Image push failed. See Output window for details.');
+                        showOutput(stderr, "Docker");
                         console.log(stderr);
                     }
                 });
             } else {
-                vscode.window.showErrorMessage('Image build failed.');
+                vscode.window.showErrorMessage('Image build failed. See Output window for details.');
+                showOutput(stderr, "Docker");
                 console.log(stderr);
             }
         });
@@ -704,8 +706,12 @@ function kubectlOutput(result, stdout, stderr, name) {
         vscode.window.showErrorMessage("Command failed: " + stderr);
         return;
     }
+    showOutput(stdout, name);
+};
+
+function showOutput(text, name) {
     var channel = vscode.window.createOutputChannel(name)
-    channel.append(stdout);
+    channel.append(text);
     channel.show();
 };
 


### PR DESCRIPTION
Determining an image name requires that the VS Code workspace defines a rootPath, which does not happen when the user has files open instead of a folder.  The generic VS Code 'command execution error' message does not help the user to diagnose this.  This PR adds a message explaining to the user what they need to do.