### PR TITLE
Fixed terminal command not working on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "0.0.7",
     "publisher": "brendandburns",
     "engines": {
-        "vscode": "^1.1.0"
+        "vscode": "^1.6.0"
     },
     "categories": [
         "Other"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -855,7 +855,7 @@ function execKubernetes(isTerminal) {
             }
 
             if (isTerminal) {
-                const terminalExecCmd = ['exec', '-it', pod.metadata.name, cmd];
+                const terminalExecCmd : string[] = ['exec', '-it', pod.metadata.name, cmd];
                 var term = vscode.window.createTerminal('exec', 'kubectl', terminalExecCmd);
                 term.show();
             } else {


### PR DESCRIPTION
The Kubernetes Terminal command was not working correctly.  The currying of the execKubernetes function seemed not to be functioning, and on Windows it seems that VS Code createTerminal() needed to be told to invoke `kubectl.exe` not just `kubectl`.  Also amended the `terminal` branch to check the configuration variable for the kubectl path.