### PR TITLE
Command to configure Kubernetes for Azure Container Service

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "onCommand:extension.vsKubernetesTerminal",
         "onCommand:extension.vsKubernetesDiff",
         "onCommand:extension.vsKubernetesDebug",
-        "onCommand:extension.vsKubernetesRemoveDebug"
+        "onCommand:extension.vsKubernetesRemoveDebug",
+        "onCommand:extension.vsKubernetesConfigureFromAcs"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -99,6 +100,9 @@
         }, {
             "command": "extension.vsKubernetesRemoveDebug",
             "title": "Kubernetes Remove Debug"
+        }, {
+            "command": "extension.vsKubernetesConfigureFromAcs",
+            "title": "Kubernetes Configure from ACS"
         }]
     },
     "scripts": {

--- a/src/acs.ts
+++ b/src/acs.ts
@@ -1,0 +1,46 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as shell from './shell';
+
+export function selectSubscription(onSelection, onNone, onError) {
+    // prereq: az login
+    //   -- how and when can we detect if not logged in - think account set fails but not account list?
+    shell.exec("az account list --query [*].name", function(code, stdout, stderr) {
+        if (code === 0 && !stderr) {  // az account list returns exit code 0 even if not logged in
+            var accountNames = JSON.parse(stdout);
+            switch (accountNames.length) {
+                case 0:
+                    onNone();
+                    break;
+                case 1:
+                    onSelection(accountNames[0]);
+                    break;
+                default:
+                    // We avoid using the default subscription because if the
+                    // user has just logged in then it will be set to the first
+                    // one in the list.  As configuration is an infrequent operation,
+                    // it's better to ask and be sure.
+                    vscode.window.showQuickPick(accountNames, { placeHolder: "Select Azure subscription" }).then(subName =>
+                    {
+                        if (subName) {
+                            vscode.window.showWarningMessage('This will select ' + subName + ' for all Azure CLI operations.', 'OK').then(choice =>{
+                                if (choice == 'OK') {
+                                    shell.exec('az account set --subscription "' + subName + '"', function (code, stdout, stderr) {
+                                        if (code === 0 && !stderr) {
+                                            onSelection(subName);
+                                        } else {
+                                            onError(stderr);
+                                        }
+                                    });
+                                }
+                            });
+                        }
+                    });
+            }
+        } else {
+            onError(stderr);
+        }
+
+    });
+}

--- a/src/acs.ts
+++ b/src/acs.ts
@@ -89,14 +89,14 @@ export function installCli(onInstall, onError) {
         var appDataDir = process.env['LOCALAPPDATA'];
         installDir = appDataDir + '\\kubectl';
         installFile = installDir + '\\kubectl.exe';
-        cmd = 'md "' + installDir + '" && ' + cmdCore + ' --install-location="' + installFile + '"';
+        cmd = `(if not exist "${installDir}" md "${installDir}") & ${cmdCore} --install-location="${installFile}`;
     } else {
         // Bah, the default Linux install location requires admin permissions too!
         // Fortunately, $HOME/bin is on the path albeit not created by default.
         var homeDir = process.env['HOME'];
         installDir = homeDir + '/bin';
         installFile = installDir + '/kubectl';
-        cmd = 'mkdir "' + installDir + '" && ' + cmdCore + ' --install-location="' + installFile + '"';
+        cmd = `mkdir "${installDir}" ; ${cmdCore} --install-location="${installFile}`;
     }
     shell.exec(cmd, function(code, stdout, stderr) {
         if (code === 0 && !stderr) {

--- a/src/acs.ts
+++ b/src/acs.ts
@@ -124,7 +124,7 @@ export function installCli(onInstall, onError) {
         var homeDir = process.env['HOME'];
         installDir = homeDir + '/bin';
         installFile = installDir + '/kubectl';
-        cmd = `mkdir "${installDir}" ; ${cmdCore} --install-location="${installFile}"`;
+        cmd = `mkdir -p "${installDir}" ; ${cmdCore} --install-location="${installFile}"`;
     }
     shell.exec(cmd, function(code, stdout, stderr) {
         if (code === 0 && !stderr) {

--- a/src/acs.ts
+++ b/src/acs.ts
@@ -108,6 +108,18 @@ export function installCli(onInstall, onError) {
     });
 }
 
+export function getCredentials(cluster : Cluster, onSuccess, onError) {
+    var cmd = 'az acs kubernetes get-credentials -n ' + cluster.name + ' -g ' + cluster.resourceGroup;
+    shell.exec(cmd, function(code, stdout, stderr) {
+        if (code === 0 && !stderr) {
+            onSuccess();
+        } else {
+            onError(stderr);
+        }
+    });
+
+}
+
 function clusterQuickPick(cluster) : ClusterQuickPick {
     return new ClusterQuickPick(cluster);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,7 +104,7 @@ function checkForKubectlInternal(errorMessageMode, handler) {
 
 function getCheckKubectlContextMessage(errorMessageMode) {
     if (errorMessageMode === 'activation') {
-        return ' Extension will not function correctly.';
+        return ' Kubernetes commands other than configuration will not function correctly.';
     } else if (errorMessageMode === 'command') {
         return ' Cannot execute command.';
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1116,7 +1116,18 @@ function configureFromAcsKubernetes() {
     //   -- how and when can we detect if not logged in - think account set fails but not account list?
     acs.selectSubscription(
         subName => {
-            vscode.window.showInformationMessage('Selected ' + subName + ' but command is not implemented');
+            acs.selectKubernetesClustersFromActiveSubscription(
+                cluster => {
+                    vscode.window.showInformationMessage('Selected ' + cluster.name + ' in ' + cluster.resourceGroup + ' but command is not implemented');
+                },
+                () => {
+                    vscode.window.showInformationMessage('No Kubernetes clusters in subscription ' + subName);
+                },
+                err => {
+                    vscode.window.showErrorMessage('Unable to select a Kubernetes cluster in ' + subName + '. See Output window for error.');
+                    showOutput(err, 'Kubernetes Configure from ACS');
+                }
+            );
         },
         () => {
             vscode.window.showInformationMessage('No Azure subscriptions.');
@@ -1126,14 +1137,6 @@ function configureFromAcsKubernetes() {
             showOutput(err, 'Kubernetes Configure from ACS');
         }
     );
-    // az acs list
-    //   [
-    //     { orchestratorProfile :
-    //       { orchestratorType : "Kubernetes" }
-    //     },
-    //     name: <capture>
-    //     resourceGroup: <capture>,
-    // ]
     // az acs kubernetes install-cli (opt: --install-location)
     // az acs kubernetes get-credentials -n cluster_name -g resource_group
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1166,8 +1166,14 @@ function acsInstallCli() {
 }
 
 function acsGetCredentials(cluster) {
-    // az acs kubernetes get-credentials -n cluster_name -g resource_group
-    vscode.window.showWarningMessage('Getting credentials for ' + cluster.name + ' in ' + cluster.resourceGroup + ' - not implemented');
+    acsShowProgress("Configuring Kubernetes credentials for " + cluster.name + "...");
+    acs.getCredentials(cluster,
+        () => {
+            vscode.window.showInformationMessage('Successfully configured kubectl with Azure Container Service cluster credentials.');
+        },
+        err => {
+            acsShowError('Unable to get Azure Container Service cluster credentials. See Output window for error.', err);
+        });
 }
 
 function acsShowProgress(message) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,6 +46,7 @@ export function activate(context) {
         vscode.commands.registerCommand('extension.vsKubernetesDiff', diffKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesDebug', debugKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesRemoveDebug', removeDebugKubernetes),
+        vscode.commands.registerCommand('extension.vsKubernetesConfigureFromAcs', configureFromAcsKubernetes),
         vscode.languages.registerHoverProvider(
             { language: 'json', scheme: 'file' },
             { provideHover: provideHoverJson }
@@ -1130,4 +1131,23 @@ function removeDebugKubernetes() {
             })
         });
     });
+}
+
+function configureFromAcsKubernetes() {
+    // prereq: az login
+    //   -- how and when can we detect if not logged in - think account set fails but not account list?
+    // prereq: az account set --subscription "blah"
+    //   -- can find current account via az account show, or prompt via az account list
+    //      { name: <n> }
+    // az acs list
+    //   [
+    //     { orchestratorProfile :
+    //       { orchestratorType : "Kubernetes" }
+    //     },
+    //     name: <capture>
+    //     resourceGroup: <capture>,
+    // ]
+    // az acs kubernetes install-cli (opt: --install-location)
+    // az acs kubernetes get-credentials -n cluster_name -g resource_group
+    vscode.window.showInformationMessage('Not implemented');
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1112,8 +1112,23 @@ function removeDebugKubernetes() {
 }
 
 function configureFromAcsKubernetes() {
-    // prereq: az login
-    //   -- how and when can we detect if not logged in - think account set fails but not account list?
+    acsShowProgress("Verifying prerequisites...");
+    acs.verifyPrerequisites(
+        () => {
+            acsSelectSubscription();
+        },
+        (errs : Array<string>) => {
+            if (errs.length === 1) {
+                acsShowError('Missing prerequisite for Kubernetes configuration. ' + errs[0], errs[0]);
+            } else {
+                var message = errs.join('\n');
+                acsShowError('Missing prerequisites for Kubernetes configuration. See Output window for details.', message);
+            }
+        }
+    );
+}
+
+function acsSelectSubscription() {
     acsShowProgress("Retrieving Azure subscriptions...");
     acs.selectSubscription(
         subName => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1145,7 +1145,24 @@ function acsSelectCluster(subName) {
 }
 
 function acsInstallCli() {
-    // az acs kubernetes install-cli (opt: --install-location)
+    acsShowProgress("Downloading kubectl command line tool...");
+    acs.installCli(
+        (installLocation, onDefaultPath) => {
+            var message = 'kubectl installed.';
+            var details = 'kubectl installation location: ' + installLocation;
+            if (onDefaultPath) {
+                message = message + ' See Output window for details.';
+            } else {
+                message = message + ' See Output window for additional installation info.';
+                details = details + '\n***NOTE***: This location is not on your system PATH.\nAdd this directory to your path, or set the VS Code\n*vs-kubernetes.kubectl-path* config setting.';
+                acsShowOutput(details);
+            }
+            vscode.window.showInformationMessage(message);
+        },
+        err => {
+            acsShowError('Unable to download kubectl. See Output window for error.', err);
+        }
+    );
 }
 
 function acsGetCredentials(cluster) {
@@ -1154,11 +1171,20 @@ function acsGetCredentials(cluster) {
 }
 
 function acsShowProgress(message) {
-    showOutput(message, 'Kubernetes Configure from ACS');
+    acsShowOutput(message);
 }
 
 function acsShowError(message, err) {
     vscode.window.showErrorMessage(message);
-    showOutput(err, 'Kubernetes Configure from ACS');
+    acsShowOutput(err);
 }
 
+var _acsOutputChannel : vscode.OutputChannel = null;
+
+function acsShowOutput(message) {
+    if (!_acsOutputChannel) {
+        _acsOutputChannel = vscode.window.createOutputChannel('Kubernetes Configure from ACS');
+    }
+    _acsOutputChannel.appendLine(message);
+    _acsOutputChannel.show();
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1116,27 +1116,43 @@ function configureFromAcsKubernetes() {
     //   -- how and when can we detect if not logged in - think account set fails but not account list?
     acs.selectSubscription(
         subName => {
-            acs.selectKubernetesClustersFromActiveSubscription(
-                cluster => {
-                    vscode.window.showInformationMessage('Selected ' + cluster.name + ' in ' + cluster.resourceGroup + ' but command is not implemented');
-                },
-                () => {
-                    vscode.window.showInformationMessage('No Kubernetes clusters in subscription ' + subName);
-                },
-                err => {
-                    vscode.window.showErrorMessage('Unable to select a Kubernetes cluster in ' + subName + '. See Output window for error.');
-                    showOutput(err, 'Kubernetes Configure from ACS');
-                }
-            );
+            acsSelectCluster(subName);
         },
         () => {
             vscode.window.showInformationMessage('No Azure subscriptions.');
         },
         err => {
-            vscode.window.showErrorMessage('Unable to list Azure subscriptions. See Output window for error.');
-            showOutput(err, 'Kubernetes Configure from ACS');
+            acsShowError('Unable to list Azure subscriptions. See Output window for error.', err);
         }
     );
-    // az acs kubernetes install-cli (opt: --install-location)
-    // az acs kubernetes get-credentials -n cluster_name -g resource_group
 }
+
+function acsSelectCluster(subName) {
+    acs.selectKubernetesClustersFromActiveSubscription(
+        cluster => {
+            acsInstallCli();
+            acsGetCredentials(cluster);
+        },
+        () => {
+            vscode.window.showInformationMessage('No Kubernetes clusters in subscription ' + subName);
+        },
+        err => {
+            acsShowError('Unable to select a Kubernetes cluster in ' + subName + '. See Output window for error.', err);
+         }
+     );
+}
+
+function acsInstallCli() {
+    // az acs kubernetes install-cli (opt: --install-location)
+}
+
+function acsGetCredentials(cluster) {
+    // az acs kubernetes get-credentials -n cluster_name -g resource_group
+    vscode.window.showWarningMessage('Getting credentials for ' + cluster.name + ' in ' + cluster.resourceGroup + ' - not implemented');
+}
+
+function acsShowError(message, err) {
+    vscode.window.showErrorMessage(message);
+    showOutput(err, 'Kubernetes Configure from ACS');
+}
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1114,6 +1114,7 @@ function removeDebugKubernetes() {
 function configureFromAcsKubernetes() {
     // prereq: az login
     //   -- how and when can we detect if not logged in - think account set fails but not account list?
+    acsShowProgress("Retrieving Azure subscriptions...");
     acs.selectSubscription(
         subName => {
             acsSelectCluster(subName);
@@ -1128,6 +1129,7 @@ function configureFromAcsKubernetes() {
 }
 
 function acsSelectCluster(subName) {
+    acsShowProgress("Retrieving Azure Container Service Kubernetes clusters...");
     acs.selectKubernetesClustersFromActiveSubscription(
         cluster => {
             acsInstallCli();
@@ -1149,6 +1151,10 @@ function acsInstallCli() {
 function acsGetCredentials(cluster) {
     // az acs kubernetes get-credentials -n cluster_name -g resource_group
     vscode.window.showWarningMessage('Getting credentials for ' + cluster.name + ' in ' + cluster.resourceGroup + ' - not implemented');
+}
+
+function acsShowProgress(message) {
+    showOutput(message, 'Kubernetes Configure from ACS');
 }
 
 function acsShowError(message, err) {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -11,11 +11,24 @@ export function isUnix() : boolean {
     return !isWindows();
 }
 
+export function home() {
+    var homeVar = isWindows() ? 'USERPROFILE' : 'HOME';
+    return process.env[homeVar];
+}
+
+export function combinePath(basePath, relativePath : string) {
+    var separator = '/';
+    if (isWindows()) {
+        relativePath = relativePath.replace(/\//g, '\\');
+        separator = '\\';
+    }
+    return basePath + separator + relativePath;
+}
+
 export function execOpts() {
     var env = process.env;
     if (isWindows()) {
-        var home = process.env['USERPROFILE'];
-        env = Object.assign({ }, env, { 'HOME': home });
+        env = Object.assign({ }, env, { 'HOME': home() });
     }
     var opts = {
         'cwd': vscode.workspace.rootPath,

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,0 +1,28 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as shelljs from 'shelljs';
+
+export function execOpts() {
+    var home = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
+    var opts = {
+        'cwd': vscode.workspace.rootPath,
+        'env': {
+            'HOME': home
+        },
+        'async': true
+    };
+    return opts;
+}
+
+export function exec(cmd, handler) {
+    try {
+        execCore(cmd, execOpts(), handler);
+    } catch (ex) {
+        vscode.window.showErrorMessage(ex);
+    }
+}
+
+export function execCore(cmd, opts, handler) {
+    shelljs.exec(cmd, opts, handler);
+}

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -3,13 +3,23 @@
 import * as vscode from 'vscode';
 import * as shelljs from 'shelljs';
 
+export function isWindows() : boolean {
+    return (process.platform == 'win32');
+}
+
+export function isUnix() : boolean {
+    return !isWindows();
+}
+
 export function execOpts() {
-    var home = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
+    var env = process.env;
+    if (isWindows()) {
+        var home = process.env['USERPROFILE'];
+        env = Object.assign({ }, env, { 'HOME': home });
+    }
     var opts = {
         'cwd': vscode.workspace.rootPath,
-        'env': {
-            'HOME': home
-        },
+        'env': env,
         'async': true
     };
     return opts;


### PR DESCRIPTION
A Microsoft user who is using vs-kubernetes to do Azure Container Service demos requested the ability to easily configure the extension to manage an ACS Kubernetes cluster.  This PR adds a new command, `Kubernetes Configure from ACS`, which when activated:

* Prompts the user to select a subscription
* Prompts the user to select an ACS Kubernetes cluster within that subscription
* Downloads kubectl using `az acs kubernetes install-cli`
* Configures kubectl using `az acs kubernetes get-credentials`

The new command depends on Azure CLI 2.0 being installed.  It has been tested on Windows and Linux but not on Mac.