### PR TITLE
Fixed issues if the folder name had spaces in it

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "onCommand:extension.vsKubernetesExec",
         "onCommand:extension.vsKubernetesTerminal",
         "onCommand:extension.vsKubernetesDiff",
+        "onCommand:extension.vsKubernetesScale",
         "onCommand:extension.vsKubernetesDebug",
         "onCommand:extension.vsKubernetesRemoveDebug",
         "onCommand:extension.vsKubernetesConfigureFromAcs"
@@ -94,6 +95,9 @@
         }, {
             "command": "extension.vsKubernetesDiff",
             "title": "Kubernetes Diff"
+        }, {
+            "command": "extension.vsKubernetesScale",
+            "title": "Kubernetes Scale"
         }, {
             "command": "extension.vsKubernetesDebug",
             "title": "Kubernetes Debug"

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
         "js-yaml": "^3.8.2",
         "dockerfile-parse": "^0.2.0",
         "k8s": "^0.4.12",
+        "tmp": "^0.0.31",
         "pluralize": "^4.0.0"
     },
     "devDependencies": {

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,0 +1,8 @@
+export function sanitiseTag(name : string) {
+    // Name components may contain lowercase letters, digits and separators.
+    // A separator is defined as a period, one or two underscores, or one or
+    // more dashes. A name component may not start or end with a separator.
+    // https://docs.docker.com/engine/reference/commandline/tag/#extended-description
+
+    return name.toLowerCase().replace(/[^a-z0-9._-]/g, '-');
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import * as dockerfileParse from 'dockerfile-parse';
 import * as explainer from './explainer';
 import * as shell from './shell';
 import * as acs from './acs';
+import * as kuberesources from './kuberesources';
 import * as kubeconfig from './kubeconfig';
 
 const WINDOWS = 'win32';
@@ -47,6 +48,7 @@ export function activate(context) {
         vscode.commands.registerCommand('extension.vsKubernetesExec', execKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesTerminal', terminalKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesDiff', diffKubernetes),
+        vscode.commands.registerCommand('extension.vsKubernetesScale', scaleKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesDebug', debugKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesRemoveDebug', removeDebugKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesConfigureFromAcs', configureFromAcsKubernetes),
@@ -393,7 +395,7 @@ function getTextForActiveWindow(callback) {
 }
 
 function loadKubernetes() {
-    promptKindName("load", { nameOptional: true }, function (value) {
+    promptKindName(kuberesources.commonKinds, "load", { nameOptional: true }, function (value) {
         kubectlInternal(" -o json get " + value, function (result, stdout, stderr) {
             if (result !== 0) {
                 vscode.window.showErrorMessage("Get command failed: " + stderr);
@@ -474,7 +476,7 @@ function getKubernetes() {
         maybeRunKubernetesCommandForActiveWindow('get --no-headers -o wide -f ');
         return;
     }
-    findKindNameOrPrompt('get', { nameOptional: true }, function (value) {
+    findKindNameOrPrompt(kuberesources.commonKinds, 'get', { nameOptional: true }, function (value) {
         kubectl(" get " + value + " -o wide --no-headers");
     });
 }
@@ -554,6 +556,29 @@ function _findNameAndImageInternal(fn) {
     });
 }
 
+function scaleKubernetes() {
+    var kindName = findKindNameOrPrompt(kuberesources.scaleableKinds, 'scale', {}, kindName => {
+        promptScaleKubernetes(kindName);
+    });
+}
+
+function promptScaleKubernetes(kindName : string) {
+    vscode.window.showInputBox({ prompt: `How many replicas would you like to scale ${kindName} to?` }).then(value => {
+        if (value) {
+            let replicas = parseFloat(value);
+            if (Number.isInteger(replicas) && replicas >= 0) {
+                invokeScaleKubernetes(kindName, replicas);
+            } else {
+                vscode.window.showErrorMessage('Replica count must be a non-negative integer');
+            }
+        }
+    });
+}
+
+function invokeScaleKubernetes(kindName : string, replicas : number) {
+    kubectl(`scale --replicas=${replicas} ${kindName}`);
+}
+
 function runKubernetes() {
     buildPushThenExec(function (name, image) {
         kubectlInternal(`run ${name} --image=${image}`, kubectlDone);
@@ -610,28 +635,31 @@ function findKindNameForText(text) {
     }
 }
 
-function findKindNameOrPrompt(descriptionVerb, opts, handler) {
+function findKindNameOrPrompt(resourceKinds : kuberesources.ResourceKind[], descriptionVerb, opts, handler) {
     var kindName = findKindName();
     if (kindName === null) {
-        promptKindName(descriptionVerb, opts, handler);
+        promptKindName(resourceKinds, descriptionVerb, opts, handler);
     } else {
         handler(kindName);
     }
 }
 
-function promptKindName(descriptionVerb, opts, handler) {
+function promptKindName(resourceKinds : kuberesources.ResourceKind[], descriptionVerb, opts, handler) {
     vscode.window.showInputBox({ prompt: "What resource do you want to " + descriptionVerb + "?", placeHolder: 'Empty string to be prompted' }).then(function (resource) {
         if (resource === '') {
-            quickPickKindName(opts, handler);
+            quickPickKindName(resourceKinds, opts, handler);
+        } else if (resource === undefined) {
+            return;
         } else {
             handler(resource);
         }
     });
 }
 
-function quickPickKindName(opts, handler) {
-    vscode.window.showQuickPick(['deployment', 'job', 'pod', 'service']).then(function (kind) {
-        if (kind) {
+function quickPickKindName(resourceKinds : kuberesources.ResourceKind[], opts, handler) {
+    vscode.window.showQuickPick(resourceKinds).then(function (resourceKind) {
+        if (resourceKind) {
+            let kind = resourceKind.abbreviation;
             kubectlInternal("get " + kind, function (code, stdout, stderr) {
                 if (code === 0) {
                     var names = parseNamesFromKubectlLines(stdout);
@@ -658,7 +686,7 @@ function quickPickKindName(opts, handler) {
                             });
                         }
                     } else {
-                        vscode.window.showInformationMessage("No resources of type " + kind + " in cluster");
+                        vscode.window.showInformationMessage("No resources of type " + resourceKind.displayName + " in cluster");
                     }
                 } else {
                     vscode.window.showErrorMessage(stderr);
@@ -806,7 +834,7 @@ function getPorts() {
 }
 
 function describeKubernetes() {
-    findKindNameOrPrompt('describe', { nameOptional: true }, function (value) {
+    findKindNameOrPrompt(kuberesources.commonKinds, 'describe', { nameOptional: true }, function (value) {
         var fn = curry(kubectlOutput, value + "-describe");
         kubectlInternal(' describe ' + value, fn);
     });
@@ -919,7 +947,7 @@ function findBinary(binName, callback) {
 }
 
 const deleteKubernetes = function () {
-    findKindNameOrPrompt('delete', { nameOptional: true }, function (kindName) {
+    findKindNameOrPrompt(kuberesources.commonKinds, 'delete', { nameOptional: true }, function (kindName) {
         if (kindName) {
             var commandArgs = kindName;
             if (!containsName(kindName)) {

--- a/src/kuberesources.ts
+++ b/src/kuberesources.ts
@@ -1,0 +1,32 @@
+import * as vscode from 'vscode';
+
+export class ResourceKind implements vscode.QuickPickItem {
+    constructor (readonly displayName : string, readonly abbreviation : string) {
+    }
+
+    get label() { return this.displayName; }
+    get description() { return ''; }
+}
+
+export const allKinds = {
+    deployment: new ResourceKind("Deployment", "deployment"),
+    replicaSet: new ResourceKind("ReplicaSet", "rs"),
+    replicationController: new ResourceKind("Replication Controller", "rc"),
+    job: new ResourceKind("Job", "job"),
+    pod: new ResourceKind("Pod", "pod"),
+    service: new ResourceKind("Service", "service"),
+}
+
+export const commonKinds = [
+    allKinds.deployment,
+    allKinds.job,
+    allKinds.pod,
+    allKinds.service,
+]
+
+export const scaleableKinds = [
+    allKinds.deployment,
+    allKinds.replicaSet,
+    allKinds.replicationController,
+    allKinds.job,
+]


### PR DESCRIPTION
There were a couple of bugs if the folder name had spaces in it:

* `docker build` failed due to invalid generated tag.  Fixed by changing illegal characters (not just spaces but also other characters permitted in directory names but not Docker tags, such as upper-case characters or punctuation) to dashes.
* `kubectl` commands using `-f` option failed due to path not being quoted (e.g. `kubectl get -f c:\hello world\test.yaml` - path was interpreted as `c:\hello`).  Fixed by quoting path.

Also, there was an issue with `-f` when the current JSON/YAML file had not been saved; this was also fixed.