### PR TITLE
Convert remaining files to TypeScript

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/test" ],
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
             "stopOnEntry": false
         }
     ]

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -5,20 +5,16 @@
 // Please refer to their documentation on https://mochajs.org/ for help.
 //
 
-var fs = require('fs');
-var path = require('path');
+import * as fs from 'fs';
+import * as path from 'path';
 
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-// var vscode = require('vscode');
-// var extension = require('../extension');
-var explainer = require('../out/src/explainer');  // TODO: TyyyypppeeScriippptt!!!
-var textassert = require('../out/test/textassert');
+import * as explainer from '../src/explainer';
+import * as textassert from '../test/textassert';
 
 // Defines a Mocha test suite to group tests of similar kind together
 suite("Extension Tests", function() {
 
-    var swaggerJson = fs.readFileSync(path.join(__dirname, 'kube-swagger.json'), 'utf8');
+    var swaggerJson = fs.readFileSync(path.join(__dirname, '../../test/kube-swagger.json'), 'utf8');
     var swagger = JSON.parse(swaggerJson);
 
     test("Kind documentation includes kind name - Deployment", function() {

--- a/test/index.ts
+++ b/test/index.ts
@@ -10,7 +10,7 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-var testRunner = require('vscode/lib/testrunner');
+import * as testRunner from 'vscode/lib/testrunner';
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info


### PR DESCRIPTION
The unit tests were still JavaScript; this PR converts them to TypeScript (without making any additional changes).