### PR TITLE
Fix for rogue explanations when explain not activated

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,6 +134,7 @@ function providerHover(document, position, token, syntax) {
     return new Promise(async (resolve) => {
         if (!explainActive) {
             resolve(null);
+            return;
         }
 
         const body = document.getText();
@@ -144,11 +145,13 @@ function providerHover(document, position, token, syntax) {
         } catch (err) {
             // Bad document
             resolve(null);
+            return;
         }
 
         // Not a k8s object.
         if (!obj.kind) {
             resolve(null);
+            return;
         }
 
         let property = findProperty(document.lineAt(position.line)),


### PR DESCRIPTION
The explain behaviour was kicking in as soon as the extension was activated, and was causing errors on arbitrary JSON files (such as settings.json) if you opened them after doing any command.  This was due to the 'provide hover' method resolving a promise with a 'no action' value, but continuing down the method to the explain call instead of exiting after resolving.

The quick fix is to return from the 'provide hover' method immediately after resolving the promise.  A longer term fix would be to convert the method to use async/await.