### PR TITLE
Fixed docs and intellisense for Kubernetes config settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ menu (`ctrl-shift-p`)
 
 ## Extension Settings
 
-   * `vs-kubernetes.namespace` - The namespace to use for all commands
-   * `vs-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
+   * `vs-kubernetes` - Parent for Kubernetes-related extension settings
+       * `vs-kubernetes.namespace` - The namespace to use for all commands
+       * `vs-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
    * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'
 
 ## Known Issues

--- a/package.json
+++ b/package.json
@@ -36,15 +36,21 @@
             "type": "object",
             "title": "Kubernetes configuration",
             "properties": {
-                "vs-kubernetes.namespace": {
-                    "type": "string",
-                    "default": "default",
-                    "description": "The namespace to use for all commands"
-                },
-                "vs-kubernetes.kubectl-path": {
-                    "type": "string",
-                    "default": null,
-                    "description": "File path to a kubectl binary."
+                "vs-kubernetes": {
+                    "type": "object",
+                    "description": "Kubernetes configuration",
+                    "properties": {
+                        "vs-kubernetes.namespace": {
+                            "type": "string",
+                            "default": "default",
+                            "description": "The namespace to use for all commands"
+                        },
+                        "vs-kubernetes.kubectl-path": {
+                            "type": "string",
+                            "default": null,
+                            "description": "File path to a kubectl binary."
+                        }
+                    }
                 },
                 "vsdocker.imageUser": {
                     "type": "string",


### PR DESCRIPTION
The Kubernetes configuration options (namespace and kubectl path) are not top-level, but are nested under a `vs-kubernetes` top-level entry.  Previously the docs did not reflect this; ditto package.json, which resulted in incorrect intellisense.  This PR updates the documentation and metadata to accurately reflect the code.