### PR TITLE
Explorer view of Kubernetes resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,13 @@
             ]
         },
         "menus": {
+            "view/title": [
+                {
+                    "command" : "extension.vsKubernetesRefreshExplorer",
+                    "when": "view == extension.vsKubernetesExplorer",
+                    "group": "navigation"
+                }
+            ],
             "view/item/context": [
                 {
                     "command": "extension.vsKubernetesLoad",
@@ -83,6 +90,12 @@
                     "command": "extension.vsKubernetesTerminal",
                     "group": "1",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pods"
+                }
+            ],
+            "commandPalette": [
+                {
+                    "command" : "extension.vsKubernetesRefreshExplorer",
+                    "when": "view == extension.vsKubernetesExplorer"
                 }
             ]
         },
@@ -140,6 +153,9 @@
         }, {
             "command": "extension.vsKubernetesConfigureFromAcs",
             "title": "Kubernetes Configure from ACS"
+        }, {
+            "command": "extension.vsKubernetesRefreshExplorer",
+            "title": "Refresh"
         }]
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,12 @@
             "view/item/context": [
                 {
                     "command": "extension.vsKubernetesLoad",
+                    "group": "0",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
+                },
+                {
+                    "command": "extension.vsKubernetesDescribe",
+                    "group": "2",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
                 },
                 {
@@ -89,6 +95,11 @@
                 {
                     "command": "extension.vsKubernetesTerminal",
                     "group": "1",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
+                },
+                {
+                    "command": "extension.vsKubernetesDescribe",
+                    "group": "2",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "0.0.8",
     "publisher": "brendandburns",
     "engines": {
-        "vscode": "^1.6.0"
+        "vscode": "^1.13.0"
     },
     "categories": [
         "Other"
@@ -28,7 +28,8 @@
         "onCommand:extension.vsKubernetesScale",
         "onCommand:extension.vsKubernetesDebug",
         "onCommand:extension.vsKubernetesRemoveDebug",
-        "onCommand:extension.vsKubernetesConfigureFromAcs"
+        "onCommand:extension.vsKubernetesConfigureFromAcs",
+        "onView:extension.vsKubernetesExplorer"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -58,6 +59,14 @@
                     "description": "Image prefix for docker images ie 'docker.io/brendanburns'"
                 }
             }
+        },
+        "views": {
+            "explorer": [
+                {
+                    "id": "extension.vsKubernetesExplorer",
+                    "name": "Kubernetes"
+                }
+            ]
         },
         "commands": [{
             "command": "extension.vsKubernetesCreate",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
                     "command": "extension.vsKubernetesTerminal",
                     "group": "1",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
+                },
+                {
+                    "command": "extension.vsKubernetesLogs",
+                    "group": "2",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 }
             ],
             "commandPalette": [

--- a/package.json
+++ b/package.json
@@ -84,12 +84,12 @@
                 {
                     "command": "extension.vsKubernetesLoad",
                     "group": "0",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pods"
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {
                     "command": "extension.vsKubernetesTerminal",
                     "group": "1",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pods"
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 }
             ],
             "commandPalette": [

--- a/package.json
+++ b/package.json
@@ -73,6 +73,16 @@
                 {
                     "command": "extension.vsKubernetesLoad",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
+                },
+                {
+                    "command": "extension.vsKubernetesLoad",
+                    "group": "0",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pods"
+                },
+                {
+                    "command": "extension.vsKubernetesTerminal",
+                    "group": "1",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pods"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -68,6 +68,14 @@
                 }
             ]
         },
+        "menus": {
+            "view/item/context": [
+                {
+                    "command": "extension.vsKubernetesLoad",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
+                }
+            ]
+        },
         "commands": [{
             "command": "extension.vsKubernetesCreate",
             "title": "Kubernetes Create"

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+import * as shell from './shell';
+import { Kubectl } from './kubectl';
+import { Host } from './host';
+
+export class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObject> {
+
+    constructor(private readonly kubectl : Kubectl, private readonly host : Host) {}
+
+    getTreeItem(element: KubernetesObject) : vscode.TreeItem | Thenable<vscode.TreeItem> {
+        return new vscode.TreeItem(element.id, element.isLeaf ? vscode.TreeItemCollapsibleState.None : vscode.TreeItemCollapsibleState.Collapsed);
+    }
+
+    getChildren(parent? : KubernetesObject) : vscode.ProviderResult<KubernetesObject[]> {
+        if (parent) {
+            return getChildren(parent, this.kubectl, this.host);
+        }
+        return [
+            new KubernetesKind("Deployments"),
+            new KubernetesKind("Jobs"),
+            new KubernetesKind("Pods")
+        ];
+    }
+}
+
+function isKind(obj: KubernetesObject) : obj is KubernetesKind {
+    return !!(<KubernetesKind>obj).kind;
+}
+
+async function getChildren(parent : KubernetesObject, kubectl: Kubectl, host: Host) : Promise<KubernetesObject[]> {
+    if (isKind(parent)) {
+        const childrenLines = await kubectl.asLines("get " + parent.kind.toLowerCase());
+        if (shell.isShellResult(childrenLines)) {
+            host.showErrorMessage(childrenLines.stderr);
+            return [ { id: "Error", isLeaf: true } ];
+        }
+        return childrenLines.map((l) => parse(l));
+    }
+    return [];
+}
+
+function parse(kubeLine : string) : KubernetesObject {
+    const bits = kubeLine.split(' ');
+    return { id: bits[0], isLeaf: true };
+}
+
+interface KubernetesObject {
+    readonly id : string;
+    readonly isLeaf : boolean;
+}
+
+class KubernetesKind implements KubernetesObject {
+    readonly id: string;
+    constructor(readonly kind: string) {
+        this.id = kind;
+    }
+    readonly isLeaf = false;
+}

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -8,6 +8,7 @@ export function create(kubectl : Kubectl, host : Host) : vscode.TreeDataProvider
 }
 
 export interface ResourceNode {
+    readonly id : string;
     readonly resourceId : string;
 }
 
@@ -25,6 +26,9 @@ class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObject> {
                 arguments: [ element ]
             };
             treeItem.contextValue = "vsKubernetes.resource";
+            if (element.resourceId.startsWith('pods')) {
+                treeItem.contextValue = "vsKubernetes.resource.pods";
+            }
         }
         return treeItem;
     }

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -7,6 +7,10 @@ export function create(kubectl : Kubectl, host : Host) : vscode.TreeDataProvider
     return new KubernetesExplorer(kubectl, host);
 }
 
+export interface ResourceNode {
+    readonly resourceId : string;
+}
+
 class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObject> {
 
     constructor(private readonly kubectl : Kubectl, private readonly host : Host) {}
@@ -18,8 +22,9 @@ class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObject> {
             treeItem.command = {
                 command: "extension.vsKubernetesLoad",
                 title: "Load",
-                arguments: [ element.resourceId ]
+                arguments: [ element ]
             };
+            treeItem.contextValue = "vsKubernetes.resource";
         }
         return treeItem;
     }
@@ -72,7 +77,7 @@ class KubernetesKind implements KubernetesObject {
     }
 }
 
-class KubernetesResource implements KubernetesObject {
+class KubernetesResource implements KubernetesObject, ResourceNode {
     readonly resourceId: string;
     constructor(kind: string, readonly id: string) {
         this.resourceId = kind.toLowerCase() + '/' + id;

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -3,7 +3,7 @@ import * as shell from './shell';
 import { Kubectl } from './kubectl';
 import { Host } from './host';
 
-export function create(kubectl : Kubectl, host : Host) : vscode.TreeDataProvider<KubernetesObject> {
+export function create(kubectl : Kubectl, host : Host) : KubernetesExplorer {
     return new KubernetesExplorer(kubectl, host);
 }
 
@@ -12,7 +12,9 @@ export interface ResourceNode {
     readonly resourceId : string;
 }
 
-class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObject> {
+export class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObject> {
+	private _onDidChangeTreeData: vscode.EventEmitter<KubernetesObject | undefined> = new vscode.EventEmitter<KubernetesObject | undefined>();
+	readonly onDidChangeTreeData: vscode.Event<KubernetesObject | undefined> = this._onDidChangeTreeData.event;
 
     constructor(private readonly kubectl : Kubectl, private readonly host : Host) {}
 
@@ -43,6 +45,11 @@ class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObject> {
             new KubernetesKind("Pods")
         ];
     }
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
 }
 
 function isKind(obj: KubernetesObject) : obj is KubernetesKind {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,7 +64,7 @@ export function activate(context) {
             { language: 'yaml', scheme: 'file' },
             { provideHover: provideHoverYaml }
         ),
-        vscode.window.registerTreeDataProvider('extension.vsKubernetesExplorer', new explorer.KubernetesExplorer(kubectl, host))
+        vscode.window.registerTreeDataProvider('extension.vsKubernetesExplorer', explorer.create(kubectl, host))
     ];
 
     subscriptions.forEach((element) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import * as kuberesources from './kuberesources';
 import * as docker from './docker';
 import * as kubeconfig from './kubeconfig';
 import { create as kubectlCreate, Kubectl } from './kubectl';
+import * as explorer from './explorer';
 
 let explainActive = false;
 let swaggerSpecPromise = null;
@@ -62,7 +63,8 @@ export function activate(context) {
         vscode.languages.registerHoverProvider(
             { language: 'yaml', scheme: 'file' },
             { provideHover: provideHoverYaml }
-        )
+        ),
+        vscode.window.registerTreeDataProvider('extension.vsKubernetesExplorer', new explorer.KubernetesExplorer(kubectl, host))
     ];
 
     subscriptions.forEach((element) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,8 @@ const kubectl = kubectlCreate(host, fs, shell);
 export function activate(context) {
     kubectl.checkPresent('activation');
 
+    const treeProvider = explorer.create(kubectl, host);
+
     const subscriptions = [
         vscode.commands.registerCommand('extension.vsKubernetesCreate',
             maybeRunKubernetesCommandForActiveWindow.bind(this, 'create -f')
@@ -56,6 +58,7 @@ export function activate(context) {
         vscode.commands.registerCommand('extension.vsKubernetesDebug', debugKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesRemoveDebug', removeDebugKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesConfigureFromAcs', configureFromAcsKubernetes),
+        vscode.commands.registerCommand('extension.vsKubernetesRefreshExplorer', () => treeProvider.refresh()),
         vscode.languages.registerHoverProvider(
             { language: 'json', scheme: 'file' },
             { provideHover: provideHoverJson }
@@ -64,7 +67,7 @@ export function activate(context) {
             { language: 'yaml', scheme: 'file' },
             { provideHover: provideHoverYaml }
         ),
-        vscode.window.registerTreeDataProvider('extension.vsKubernetesExplorer', explorer.create(kubectl, host))
+        vscode.window.registerTreeDataProvider('extension.vsKubernetesExplorer', treeProvider)
     ];
 
     subscriptions.forEach((element) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -382,9 +382,9 @@ function getTextForActiveWindow(callback) {
     return;
 }
 
-function loadKubernetes(resourceId? : string) {
-    if (resourceId) {
-        loadKubernetesCore(resourceId);
+function loadKubernetes(explorerNode? : explorer.ResourceNode) {
+    if (explorerNode) {
+        loadKubernetesCore(explorerNode.resourceId);
     } else {
         promptKindName(kuberesources.commonKinds, "load", { nameOptional: true }, (value) => {
             loadKubernetesCore(value);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -814,11 +814,19 @@ function getPorts() {
     }
 }
 
-function describeKubernetes() {
-    findKindNameOrPrompt(kuberesources.commonKinds, 'describe', { nameOptional: true }, (value) => {
-        const fn = kubectlOutputTo(value + "-describe");
-        kubectl.invoke(' describe ' + value, fn);
-    });
+function describeKubernetes(explorerNode? : explorer.ResourceNode) {
+    if (explorerNode) {
+        describeKubernetesCore(explorerNode.resourceId);
+    } else {
+        findKindNameOrPrompt(kuberesources.commonKinds, 'describe', { nameOptional: true }, (value) => {
+            describeKubernetesCore(value);
+        });
+    }
+}
+
+function describeKubernetesCore(kindName : string) {
+    const fn = kubectlOutputTo(kindName + "-describe");
+    kubectl.invoke(' describe ' + kindName, fn);
 }
 
 function selectContainerForPod(pod, callback) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -887,7 +887,7 @@ function execKubernetesCore(isTerminal) {
 
 function execTerminalOnPod(podName : string, terminalCmd : string) {
     const terminalExecCmd : string[] = ['exec', '-it', podName, terminalCmd];
-    const term = vscode.window.createTerminal('exec', kubectl.path(), terminalExecCmd);
+    const term = vscode.window.createTerminal(`${terminalCmd} on ${podName}`, kubectl.path(), terminalExecCmd);
     term.show();
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -846,8 +846,12 @@ function execKubernetes() {
     execKubernetesCore(false);
 }
 
-function terminalKubernetes() {
-    execKubernetesCore(true);
+function terminalKubernetes(explorerNode? : explorer.ResourceNode) {
+    if (explorerNode) {
+        execTerminalOnPod(explorerNode.id, 'bash');
+    } else {
+        execKubernetesCore(true);
+    }
 }
 
 function execKubernetesCore(isTerminal) {
@@ -870,9 +874,7 @@ function execKubernetesCore(isTerminal) {
             }
 
             if (isTerminal) {
-                const terminalExecCmd : string[] = ['exec', '-it', pod.metadata.name, cmd];
-                const term = vscode.window.createTerminal('exec', kubectl.path(), terminalExecCmd);
-                term.show();
+                execTerminalOnPod(pod.metadata.name, cmd);
                 return;
             }
 
@@ -881,6 +883,12 @@ function execKubernetesCore(isTerminal) {
             kubectl.invoke(execCmd, fn);
         });
     });
+}
+
+function execTerminalOnPod(podName : string, terminalCmd : string) {
+    const terminalExecCmd : string[] = ['exec', '-it', podName, terminalCmd];
+    const term = vscode.window.createTerminal('exec', kubectl.path(), terminalExecCmd);
+    term.show();
 }
 
 function syncKubernetes() {

--- a/src/kuberesources.ts
+++ b/src/kuberesources.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 export class ResourceKind implements vscode.QuickPickItem {
-    constructor (readonly displayName : string, readonly abbreviation : string) {
+    constructor (readonly displayName : string, readonly pluralDisplayName : string, readonly abbreviation : string) {
     }
 
     get label() { return this.displayName; }
@@ -9,12 +9,12 @@ export class ResourceKind implements vscode.QuickPickItem {
 }
 
 export const allKinds = {
-    deployment: new ResourceKind("Deployment", "deployment"),
-    replicaSet: new ResourceKind("ReplicaSet", "rs"),
-    replicationController: new ResourceKind("Replication Controller", "rc"),
-    job: new ResourceKind("Job", "job"),
-    pod: new ResourceKind("Pod", "pod"),
-    service: new ResourceKind("Service", "service"),
+    deployment: new ResourceKind("Deployment", "Deployments", "deployment"),
+    replicaSet: new ResourceKind("ReplicaSet", "ReplicaSets", "rs"),
+    replicationController: new ResourceKind("Replication Controller", "Replication Controllers", "rc"),
+    job: new ResourceKind("Job", "Jobs", "job"),
+    pod: new ResourceKind("Pod", "Pods", "pod"),
+    service: new ResourceKind("Service", "Services", "service"),
 }
 
 export const commonKinds = [

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -81,3 +81,8 @@ function execCore(cmd : string, opts : any) : Promise<ShellResult> {
         shelljs.exec(cmd, opts, (code, stdout, stderr) => resolve({code : code, stdout : stdout, stderr : stderr}));
     });
 }
+
+export function isShellResult<T>(obj : T | ShellResult) : obj is ShellResult {
+    const sr = <ShellResult>obj;
+    return sr.code !== undefined || sr.stdout !== undefined || sr.stderr !== undefined;
+}

--- a/test/explorer.test.ts
+++ b/test/explorer.test.ts
@@ -1,0 +1,137 @@
+import * as vscode from 'vscode';
+
+import * as assert from 'assert';
+import * as textassert from './textassert';
+import * as fakes from './fakes';
+
+import { Host } from '../src/host';
+import { Shell, ShellResult } from '../src/shell';
+import { FS } from '../src/fs';
+import { create as explorerCreate } from '../src/explorer';
+
+interface FakeContext {
+    host? : any;
+    kubectl? : any;
+}
+
+function explorerCreateWithFakes(ctx : FakeContext) {
+    return explorerCreate(
+        ctx.kubectl || fakes.kubectl(),
+        ctx.host || fakes.host()
+    );
+}
+
+suite("Explorer tests", () => {
+
+    suite("getChildren method", () => {
+
+        suite("If getting the root nodes", () => {
+
+            test("...it returns a set of Kubernetes object kinds", async () => {
+                const explorer = explorerCreateWithFakes({});
+                const roots = await explorer.getChildren(undefined);
+                assert.equal(roots.length, 3);
+                for (const obj of roots) {
+                    assert.notEqual(undefined, obj['kind']);
+                }
+            });
+        });
+
+        suite("If getting child nodes", () => {
+
+            test("...kubectl requests the right objects", async () => {
+                let command : string = undefined;
+                const explorer = explorerCreateWithFakes({
+                    kubectl: fakes.kubectl({ asLines: (c) => { command = c; return ["a"]; } })
+                });
+                const parent : any = { id: 'Pods', kind: 'Pods'};
+                const nodes = await explorer.getChildren(parent);
+                assert.equal(command, "get pods");
+            });
+
+            test("...and kubectl succeeds, it returns an object per output row", async () => {
+                const explorer = explorerCreateWithFakes({
+                    kubectl: fakes.kubectl({ asLines: (_) => ["a b c", "d e f"]})
+                });
+                const parent : any = { id: 'Pods', kind: 'Pods'};
+                const nodes = await explorer.getChildren(parent);
+                assert.equal(nodes.length, 2);
+            });
+
+            test("...it parses the IDs from the kubectl output rows", async () => {
+                const explorer = explorerCreateWithFakes({
+                    kubectl: fakes.kubectl({ asLines: (_) => ["a b c", "d e f"]})
+                });
+                const parent : any = { id: 'Pods', kind: 'Pods'};
+                const nodes = await explorer.getChildren(parent);
+                assert.equal(nodes[0].id, 'a');
+                assert.equal(nodes[1].id, 'd');
+            });
+
+            test("...and kubectl fails, it returns an error node", async () => {
+                const explorer = explorerCreateWithFakes({
+                    kubectl: fakes.kubectl({ asLines: (_) => { return { code: 1, stdout: "", stderr: "Oh no!"}; } })
+                });
+                const parent : any = { id: 'Pods', kind: 'Pods'};
+                const nodes = await explorer.getChildren(parent);
+                assert.equal(nodes.length, 1);
+                assert.equal(nodes[0].id, "Error");
+            });
+
+            test("...and kubectl fails, the error is displayed", async () => {
+                let errors : string[] = [];
+                const explorer = explorerCreateWithFakes({
+                    kubectl: fakes.kubectl({ asLines: (_) => { return { code: 1, stdout: "", stderr: "Oh no!"}; } }),
+                    host: fakes.host({errors: errors})
+                });
+                const parent : any = { id: 'Pods', kind: 'Pods'};
+                const nodes = await explorer.getChildren(parent);
+                assert.equal(errors.length, 1);
+                assert.equal(errors[0], "Oh no!");
+            });
+
+            test("...and the parent is not a Kubernetes kind, it returns an empty list", async () => {
+                const explorer = explorerCreateWithFakes({});
+                const nodes = await explorer.getChildren({ id: 'my-pod' });
+                assert.equal(nodes.length, 0);
+            });
+        });
+    });
+
+    suite("getTreeItem method", () => {
+
+        suite("If getting a tree item for a Kubernetes kind", () => {
+
+            test("...it is expandable", async () => {
+                const explorer = explorerCreateWithFakes({});
+                const obj : any = { id: 'Pods', kind: 'Pods'};
+                const treeItem = await explorer.getTreeItem(obj);
+                assert.equal(treeItem.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed);
+            });
+
+            test("...its label is the ID", async () => {
+                const explorer = explorerCreateWithFakes({});
+                const obj : any = { id: 'Pods', kind: "Purple People-Eatin' Pods"};
+                const treeItem = await explorer.getTreeItem(obj);
+                assert.equal(treeItem.label, 'Pods');
+            });
+        });
+
+        suite("If getting a tree item for a Kubernetes object", () => {
+
+            test("...it is not expandable", async () => {
+                const explorer = explorerCreateWithFakes({});
+                const obj : any = { id: 'my-pod' };
+                const treeItem = await explorer.getTreeItem(obj);
+                assert.equal(treeItem.collapsibleState, vscode.TreeItemCollapsibleState.None);
+            });
+
+            test("...its label is the ID", async () => {
+                const explorer = explorerCreateWithFakes({});
+                const obj : any = { id: 'my-pod' };
+                const treeItem = await explorer.getTreeItem(obj);
+                assert.equal(treeItem.label, 'my-pod');
+            });
+        });
+    });
+});

--- a/test/explorer.test.ts
+++ b/test/explorer.test.ts
@@ -8,6 +8,7 @@ import { Host } from '../src/host';
 import { Shell, ShellResult } from '../src/shell';
 import { FS } from '../src/fs';
 import { create as explorerCreate } from '../src/explorer';
+import * as kuberesources from '../src/kuberesources';
 
 interface FakeContext {
     host? : any;
@@ -30,7 +31,7 @@ suite("Explorer tests", () => {
             test("...it returns a set of Kubernetes object kinds", async () => {
                 const explorer = explorerCreateWithFakes({});
                 const roots = await explorer.getChildren(undefined);
-                assert.equal(roots.length, 3);
+                assert.equal(roots.length, 4);
                 for (const obj of roots) {
                     assert.notEqual(undefined, obj['kind']);
                 }
@@ -44,16 +45,16 @@ suite("Explorer tests", () => {
                 const explorer = explorerCreateWithFakes({
                     kubectl: fakes.kubectl({ asLines: (c) => { command = c; return ["a"]; } })
                 });
-                const parent : any = { id: 'Pods', kind: 'Pods'};
+                const parent : any = { id: 'Pods', kind: kuberesources.allKinds.pod};
                 const nodes = await explorer.getChildren(parent);
-                assert.equal(command, "get pods");
+                assert.equal(command, "get pod");
             });
 
             test("...and kubectl succeeds, it returns an object per output row", async () => {
                 const explorer = explorerCreateWithFakes({
                     kubectl: fakes.kubectl({ asLines: (_) => ["a b c", "d e f"]})
                 });
-                const parent : any = { id: 'Pods', kind: 'Pods'};
+                const parent : any = { id: 'Pods', kind: kuberesources.allKinds.pod};
                 const nodes = await explorer.getChildren(parent);
                 assert.equal(nodes.length, 2);
             });
@@ -62,7 +63,7 @@ suite("Explorer tests", () => {
                 const explorer = explorerCreateWithFakes({
                     kubectl: fakes.kubectl({ asLines: (_) => ["a b c", "d e f"]})
                 });
-                const parent : any = { id: 'Pods', kind: 'Pods'};
+                const parent : any = { id: 'Pods', kind: kuberesources.allKinds.pod};
                 const nodes = await explorer.getChildren(parent);
                 assert.equal(nodes[0].id, 'a');
                 assert.equal(nodes[1].id, 'd');
@@ -72,7 +73,7 @@ suite("Explorer tests", () => {
                 const explorer = explorerCreateWithFakes({
                     kubectl: fakes.kubectl({ asLines: (_) => { return { code: 1, stdout: "", stderr: "Oh no!"}; } })
                 });
-                const parent : any = { id: 'Pods', kind: 'Pods'};
+                const parent : any = { id: 'Pods', kind: kuberesources.allKinds.pod};
                 const nodes = await explorer.getChildren(parent);
                 assert.equal(nodes.length, 1);
                 assert.equal(nodes[0].id, "Error");
@@ -84,7 +85,7 @@ suite("Explorer tests", () => {
                     kubectl: fakes.kubectl({ asLines: (_) => { return { code: 1, stdout: "", stderr: "Oh no!"}; } }),
                     host: fakes.host({errors: errors})
                 });
-                const parent : any = { id: 'Pods', kind: 'Pods'};
+                const parent : any = { id: 'Pods', kind: kuberesources.allKinds.pod};
                 const nodes = await explorer.getChildren(parent);
                 assert.equal(errors.length, 1);
                 assert.equal(errors[0], "Oh no!");
@@ -104,16 +105,16 @@ suite("Explorer tests", () => {
 
             test("...it is expandable", async () => {
                 const explorer = explorerCreateWithFakes({});
-                const obj : any = { id: 'Pods', kind: 'Pods'};
+                const obj : any = { id: 'Pods', kind: kuberesources.allKinds.pod};
                 const treeItem = await explorer.getTreeItem(obj);
                 assert.equal(treeItem.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed);
             });
 
-            test("...its label is the ID", async () => {
+            test("...its label is the kind plural name", async () => {
                 const explorer = explorerCreateWithFakes({});
-                const obj : any = { id: 'Pods', kind: "Purple People-Eatin' Pods"};
+                const obj : any = { id: 'Pods', kind: kuberesources.allKinds.deployment};
                 const treeItem = await explorer.getTreeItem(obj);
-                assert.equal(treeItem.label, 'Pods');
+                assert.equal(treeItem.label, 'Deployments');
             });
         });
 

--- a/test/fakes.ts
+++ b/test/fakes.ts
@@ -25,6 +25,10 @@ export interface FakeShellSettings {
     execCallback?: (cmd : string) => ShellResult;
 }
 
+export interface FakeKubectlSettings {
+    asLines? : (cmd: string) => string[] | ShellResult;
+}
+
 export function host(settings : FakeHostSettings = {}) : any {
     return {
         showErrorMessage: (message : string, ...items : string[]) => {
@@ -65,11 +69,18 @@ export function shell(settings : FakeShellSettings = {}) : any {
 
 function fakeShellExec(settings : FakeShellSettings, cmd : string) : Promise<ShellResult> {
     const defRecognised = settings.recognisedCommands || [];
-    const matching = defRecognised.filter(c => c.command === cmd);
+    const matching = defRecognised.filter((c) => c.command === cmd);
     const result = (matching.length > 0) ?
         { code: matching[0].code, stdout: matching[0].stdout || '', stderr: matching[0].stderr || ''} :
         settings.execCallback ?
             settings.execCallback(cmd) :
             { code : 9876, stdout: '', stderr: 'command was not properly faked!'};
     return new Promise<ShellResult>((resolve, reject) => resolve(result));
+}
+
+export function kubectl(settings : FakeKubectlSettings = {}) : any {
+    const asLines = settings.asLines || ((s : string) => []);
+    return {
+        asLines: (cmd) => new Promise((resolve, reject) => resolve(asLines(cmd)))
+    }
 }


### PR DESCRIPTION
This PR adds a tree view of Kubernetes resources to the Explorer pane.  Currently it shows deployments, jobs, pods and services.  Clicking a resource, or right-clicking and choosing Kubernetes Load, executes the Kubernetes Load command (load the resource info as a JSON document and display it in an editor window).  You can also right-click > Describe for verbose diagnostic info.

Pod nodes in the tree are equipped with two additional commands: Terminal (opens an integrated terminal on the pod) and Logs (displays the pod logs).

We could add further commands if desired - at one point I exposed the Delete command but I felt it was too easy to trigger accidentally so decided against it.  We probably want to avoid interactive commands such as Scale, as it will be hard for a user whose eyes are on the right-click menu to notice the prompt appearing at the top of the window.  What sort of commands would be safe and useful?