### PR TITLE
Added support for invoking Draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It also assumes that you have the following binaries on your `PATH`:
    * `kubectl`
    * `docker`
    * `git`
+   * `draft` (optional)
 
 If you don't have those on your PATH then the extension will fail in
 unexpected ways.
@@ -21,6 +22,8 @@ For setting up `kubectl` you have a couple of additional options:
 
    * If `kubectl` is not on your PATH then you can tell the extension its location using the `vs-kubernetes.kubectl-path` workspace setting. This should be the full file name and path of the kubectl binary.
    * If you are using the extension to work with an Azure Container Service then you can install and configure `kubectl` using the `Kubernetes Configure from ACS` command.
+
+For setting up `draft` you can also do this via configuration.
 
 ### Setting up the image repository path
 
@@ -74,11 +77,21 @@ menu (`ctrl-shift-p`)
 
    * `Kubernetes Configure from ACS` - Install and configure the Kubernetes command line tool (kubectl) from an Azure Container Service
 
+### Draft support
+
+[Draft](http://blog.kubernetes.io/2017/05/draft-kubernetes-container-development.html) is a tool to simplify the process of developing a new Kubernetes application, by creating the necessary deployment components and by keeping code in the cluster in sync with the code on your computer.
+
+  * `Kubernetes Draft: Create` - Set up Draft in the current folder (prerequisite for syncing using Draft)
+  * `Kubernetes Draft: Up` - Runs Draft to watch the current folder and keep the cluster in sync with it
+
+**NOTE:** Draft itself is in 'draft' form and is not yet stable. So the extension support for Draft is strictly experimental - assumptions may break, and commands and behavior may change!
+
 ## Extension Settings
 
    * `vs-kubernetes` - Parent for Kubernetes-related extension settings
        * `vs-kubernetes.namespace` - The namespace to use for all commands
        * `vs-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
+       * `vs-kubernetes.draft-path` - File path to the draft binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
    * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'
 
 ## Known Issues

--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
                             "type": "string",
                             "default": null,
                             "description": "File path to a kubectl binary."
+                        },
+                        "vs-kubernetes.draft-path": {
+                            "type": "string",
+                            "default": null,
+                            "description": "File path to a draft binary."
                         }
                     }
                 },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "onCommand:extension.vsKubernetesDebug",
         "onCommand:extension.vsKubernetesRemoveDebug",
         "onCommand:extension.vsKubernetesConfigureFromAcs",
+        "onCommand:extension.vsKubernetesDraftCreate",
         "onView:extension.vsKubernetesExplorer"
     ],
     "main": "./out/src/extension",
@@ -169,6 +170,10 @@
         }, {
             "command": "extension.vsKubernetesConfigureFromAcs",
             "title": "Kubernetes Configure from ACS"
+        }, {
+            "command": "extension.vsKubernetesDraftCreate",
+            "title": "Create",
+            "category": "Kubernetes Draft"
         }, {
             "command": "extension.vsKubernetesRefreshExplorer",
             "title": "Refresh"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "onCommand:extension.vsKubernetesRemoveDebug",
         "onCommand:extension.vsKubernetesConfigureFromAcs",
         "onCommand:extension.vsKubernetesDraftCreate",
+        "onCommand:extension.vsKubernetesDraftUp",
         "onView:extension.vsKubernetesExplorer"
     ],
     "main": "./out/src/extension",
@@ -173,6 +174,10 @@
         }, {
             "command": "extension.vsKubernetesDraftCreate",
             "title": "Create",
+            "category": "Kubernetes Draft"
+        }, {
+            "command": "extension.vsKubernetesDraftUp",
+            "title": "Up",
             "category": "Kubernetes Draft"
         }, {
             "command": "extension.vsKubernetesRefreshExplorer",

--- a/src/binutil.ts
+++ b/src/binutil.ts
@@ -1,0 +1,37 @@
+import { Shell } from './shell';
+
+export interface FindBinaryResult {
+    err : number | null;
+    output : string;
+}
+
+export async function findBinary(shell : Shell, binName : string) : Promise<FindBinaryResult> {
+    let cmd = `which ${binName}`;
+
+    if (shell.isWindows()) {
+        cmd = `where.exe ${binName}.exe`;
+    }
+
+    const opts = {
+        async: true,
+        env: {
+            HOME: process.env.HOME,
+            PATH: process.env.PATH
+        }
+    }
+
+    const execResult = await shell.execCore(cmd, opts);
+    if (execResult.code) {
+        return { err: execResult.code, output: execResult.stderr };
+    }
+
+    return { err: null, output: execResult.stdout };
+}
+
+export function execPath(shell : Shell, basePath : string) : string {
+    let bin = basePath;
+    if (shell.isWindows() && bin && !(bin.endsWith('.exe'))) {
+        bin = bin + '.exe';
+    }
+    return bin;
+}

--- a/src/draft.ts
+++ b/src/draft.ts
@@ -20,13 +20,13 @@ interface Context {
     readonly host : Host;
     readonly fs : FS;
     readonly shell : Shell;
-    draftFound : boolean;
-    draftPath : string;
+    binFound : boolean;
+    binPath : string;
 }
 
 class DraftImpl implements Draft {
     constructor(host : Host, fs : FS, shell : Shell, draftFound : boolean) {
-        this.context = { host : host, fs : fs, shell : shell, draftFound : draftFound, draftPath : 'draft' };
+        this.context = { host : host, fs : fs, shell : shell, binFound : draftFound, binPath : 'draft' };
     }
 
     private readonly context : Context;
@@ -53,7 +53,7 @@ class DraftImpl implements Draft {
 }
 
 async function checkPresent(context : Context) : Promise<boolean> {
-    if (context.draftFound) {
+    if (context.binFound) {
         return true;
     }
 
@@ -76,7 +76,7 @@ async function packs(context : Context) : Promise<string[] | undefined> {
 
 async function invoke(context : Context, args : string) : Promise<ShellResult> {
     if (await checkPresent(context)) {
-        const result = context.shell.exec(context.draftPath + ' ' + args);
+        const result = context.shell.exec(context.binPath + ' ' + args);
         return result;
     }
 }
@@ -89,7 +89,7 @@ async function path(context : Context) : Promise<string | undefined> {
 
 async function pathCore(context : Context) : Promise<string | undefined> {
     if (await checkPresent(context)) {
-        return context.draftPath;
+        return context.binPath;
     }
     return undefined;
 }
@@ -108,20 +108,20 @@ async function checkForDraftInternal(context : Context) : Promise<boolean> {
             return false;
         }
 
-        context.draftFound = true;
+        context.binFound = true;
 
         return true;
     }
 
-    context.draftFound = context.fs.existsSync(bin);
+    context.binFound = context.fs.existsSync(bin);
 
-    if (context.draftFound) {
-        context.draftPath = bin;
+    if (context.binFound) {
+        context.binPath = bin;
     } else {
         alertNoDraft(context, 'configuredFileMissing', bin + ' does not exist!');
     }
 
-    return context.draftFound;
+    return context.binFound;
 }
 
 type CheckPresentFailureReason = 'inferFailed' | 'configuredFileMissing';

--- a/src/draft.ts
+++ b/src/draft.ts
@@ -1,0 +1,151 @@
+import { Host } from './host';
+import { Shell } from './shell';
+import { FS } from './fs';
+import * as path from 'path';
+
+export interface Draft {
+    checkPresent() : Promise<boolean>;
+    isFolderMapped(dirPath: string) : boolean;
+    packs() : Promise<string[] | undefined>;
+}
+
+export function create(host : Host, fs : FS, shell : Shell) : Draft {
+    return new DraftImpl(host, fs, shell, false);
+}
+
+interface Context {
+    readonly host : Host;
+    readonly fs : FS;
+    readonly shell : Shell;
+    draftFound : boolean;
+}
+
+class DraftImpl implements Draft {
+    constructor(host : Host, fs : FS, shell : Shell, draftFound : boolean) {
+        this.context = { host : host, fs : fs, shell : shell, draftFound : draftFound };
+    }
+
+    private readonly context : Context;
+
+    checkPresent() : Promise<boolean> {
+        return checkPresent(this.context);
+    }
+
+    isFolderMapped(dirPath: string) : boolean {
+        return isFolderMapped(this.context, dirPath);
+    }
+
+    packs() : Promise<string[] | undefined> {
+        return packs(this.context);
+    }
+}
+
+async function checkPresent(context : Context) : Promise<boolean> {
+    if (context.draftFound) {
+        return true;
+    }
+
+    return await checkForDraftInternal(context);
+}
+
+async function packs(context : Context) : Promise<string[] | undefined> {
+    if (await checkPresent(context)) {
+        const dhResult = await context.shell.exec("draft home");
+        if (dhResult.code === 0) {
+            const draftHome = dhResult.stdout.trim();
+            const draftPacksDir = path.join(draftHome, 'packs');
+            const draftPacks = context.fs.dirSync(draftPacksDir);
+            return draftPacks;
+        }
+    }
+
+    return undefined;
+}
+
+// TODO: reduce duplication with kubectl module
+
+async function checkForDraftInternal(context : Context) : Promise<boolean> {
+    const
+        bin = context.host.getConfiguration('vs-kubernetes')['vs-kubernetes.draft-path'];
+
+    if (!bin) {
+        const fb = await findBinary(context, 'draft');
+
+        if (fb.err || fb.output.length === 0) {
+            alertNoDraft(context, 'inferFailed', 'Could not find "draft" binary.');
+            return false;
+        }
+
+        context.draftFound = true;
+
+        return true;
+    }
+
+    context.draftFound = context.fs.existsSync(bin);
+
+    if (!context.draftFound) {
+        alertNoDraft(context, 'configuredFileMissing', bin + ' does not exist!');
+    }
+
+    return context.draftFound;
+}
+
+type CheckPresentFailureReason = 'inferFailed' | 'configuredFileMissing';
+
+function alertNoDraft(context : Context, failureReason : CheckPresentFailureReason, message : string) : void {
+    switch (failureReason) {
+        case 'inferFailed':
+            context.host.showErrorMessage(message, 'Learn more').then(
+                (str) => {
+                    if (str !== 'Learn more') {
+                        return;
+                    }
+
+                    context.host.showInformationMessage('Add draft directory to path, or set "vs-kubernetes.draft-path" config to kubectl binary.');
+                }
+            );
+            break;
+        case 'configuredFileMissing':
+            context.host.showErrorMessage(message);
+            break;
+    }
+}
+
+// TODO: this is an exact duplicate of kubectl.findBinary
+
+interface FindBinaryResult {
+    err : number | null;
+    output : string;
+}
+
+async function findBinary(context : Context, binName : string) : Promise<FindBinaryResult> {
+    let cmd = `which ${binName}`;
+
+    if (context.shell.isWindows()) {
+        cmd = `where.exe ${binName}.exe`;
+    }
+
+    const opts = {
+        async: true,
+        env: {
+            HOME: process.env.HOME,
+            PATH: process.env.PATH
+        }
+    }
+
+    const execResult = await context.shell.execCore(cmd, opts);
+    if (execResult.code) {
+        return { err: execResult.code, output: execResult.stderr };
+    }
+
+    return { err: null, output: execResult.stdout };
+}
+
+// END TODO
+
+function isFolderMapped(context: Context, dirPath: string) : boolean {
+    // Heuristic based on files created by 'draft create'
+    const tomlFile = path.join(dirPath, '.draftignore');
+    const ignoreFile = path.join(dirPath, 'draft.toml');
+    return context.fs.existsSync(tomlFile) && context.fs.existsSync(ignoreFile);
+}

--- a/src/draft.ts
+++ b/src/draft.ts
@@ -1,12 +1,14 @@
 import { Host } from './host';
-import { Shell } from './shell';
+import { Shell, ShellResult } from './shell';
 import { FS } from './fs';
-import * as path from 'path';
+import * as syspath from 'path';
 
 export interface Draft {
     checkPresent() : Promise<boolean>;
-    isFolderMapped(dirPath: string) : boolean;
+    isFolderMapped(path: string) : boolean;
     packs() : Promise<string[] | undefined>;
+    invoke(args: string) : Promise<ShellResult>;
+    path() : Promise<string | undefined>;
 }
 
 export function create(host : Host, fs : FS, shell : Shell) : Draft {
@@ -18,11 +20,12 @@ interface Context {
     readonly fs : FS;
     readonly shell : Shell;
     draftFound : boolean;
+    draftPath : string;
 }
 
 class DraftImpl implements Draft {
     constructor(host : Host, fs : FS, shell : Shell, draftFound : boolean) {
-        this.context = { host : host, fs : fs, shell : shell, draftFound : draftFound };
+        this.context = { host : host, fs : fs, shell : shell, draftFound : draftFound, draftPath : 'draft' };
     }
 
     private readonly context : Context;
@@ -31,12 +34,20 @@ class DraftImpl implements Draft {
         return checkPresent(this.context);
     }
 
-    isFolderMapped(dirPath: string) : boolean {
-        return isFolderMapped(this.context, dirPath);
+    isFolderMapped(path: string) : boolean {
+        return isFolderMapped(this.context, path);
     }
 
     packs() : Promise<string[] | undefined> {
         return packs(this.context);
+    }
+
+    invoke(args: string) : Promise<ShellResult> {
+        return invoke(this.context, args);
+    }
+
+    path() : Promise<string | undefined> {
+        return path(this.context);
     }
 }
 
@@ -53,12 +64,35 @@ async function packs(context : Context) : Promise<string[] | undefined> {
         const dhResult = await context.shell.exec("draft home");
         if (dhResult.code === 0) {
             const draftHome = dhResult.stdout.trim();
-            const draftPacksDir = path.join(draftHome, 'packs');
+            const draftPacksDir = syspath.join(draftHome, 'packs');
             const draftPacks = context.fs.dirSync(draftPacksDir);
             return draftPacks;
         }
     }
 
+    return undefined;
+}
+
+async function invoke(context : Context, args : string) : Promise<ShellResult> {
+    if (await checkPresent(context)) {
+        const result = context.shell.exec(context.draftPath + ' ' + args);
+        return result;
+    }
+}
+
+// TODO: Windows-isation is similar to kubectl module
+async function path(context : Context) : Promise<string | undefined> {
+    let bin = await pathCore(context);
+    if (context.shell.isWindows() && bin && !(bin.endsWith('.exe'))) {
+        bin = bin + '.exe';
+    }
+    return bin;
+}
+
+async function pathCore(context : Context) : Promise<string | undefined> {
+    if (await checkPresent(context)) {
+        return context.draftPath;
+    }
     return undefined;
 }
 
@@ -83,7 +117,9 @@ async function checkForDraftInternal(context : Context) : Promise<boolean> {
 
     context.draftFound = context.fs.existsSync(bin);
 
-    if (!context.draftFound) {
+    if (context.draftFound) {
+        context.draftPath = bin;
+    } else {
         alertNoDraft(context, 'configuredFileMissing', bin + ' does not exist!');
     }
 
@@ -143,9 +179,9 @@ async function findBinary(context : Context, binName : string) : Promise<FindBin
 
 // END TODO
 
-function isFolderMapped(context: Context, dirPath: string) : boolean {
+function isFolderMapped(context: Context, path: string) : boolean {
     // Heuristic based on files created by 'draft create'
-    const tomlFile = path.join(dirPath, '.draftignore');
-    const ignoreFile = path.join(dirPath, 'draft.toml');
+    const tomlFile = syspath.join(path, '.draftignore');
+    const ignoreFile = syspath.join(path, 'draft.toml');
     return context.fs.existsSync(tomlFile) && context.fs.existsSync(ignoreFile);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1265,7 +1265,8 @@ async function execDraftCreate() {
     if (!(await draft.checkPresent())) {
         return;
     }
-    const appName = await vscode.window.showInputBox({ prompt: "Choose a name for the Helm release"});
+    const proposedAppName = path.basename(vscode.workspace.rootPath);
+    const appName = await vscode.window.showInputBox({ value: proposedAppName, prompt: "Choose a name for the Helm release"});
     if (appName) {
         await execDraftCreateApp(appName, undefined);
     }

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -6,6 +6,7 @@ export interface FS {
     readFileSync(filename : string, encoding : string) : string;
     writeFile(filename : string, data : any, callback? : (err : NodeJS.ErrnoException) => void) : void;
     writeFileSync(filename : string, data : any) : void;
+    dirSync(path: string) : string[];
 }
 
 export const fs : FS = {
@@ -14,4 +15,5 @@ export const fs : FS = {
     readFileSync: (filename, encoding) => sysfs.readFileSync(filename, encoding),
     writeFile: (filename, data, callback) => sysfs.writeFile(filename, data, callback),
     writeFileSync: (filename, data) => sysfs.writeFileSync(filename, data),
+    dirSync: (path) => sysfs.readdirSync(path),
 }

--- a/test/draft.test.ts
+++ b/test/draft.test.ts
@@ -1,0 +1,231 @@
+import * as vscode from 'vscode';
+
+import * as assert from 'assert';
+import * as textassert from './textassert';
+import * as fakes from './fakes';
+
+import { Host } from '../src/host';
+import { Shell, ShellResult } from '../src/shell';
+import { FS } from '../src/fs';
+import { create as draftCreate } from '../src/draft';
+import * as kuberesources from '../src/kuberesources';
+
+interface FakeContext {
+    host? : any;
+    fs? : any;
+    shell? : any;
+}
+
+function draftCreateWithFakes(ctx : FakeContext) {
+    return draftCreate(
+        ctx.host || fakes.host(),
+        ctx.fs || fakes.fs(),
+        ctx.shell || fakes.shell()
+    );
+}
+
+const draftFakePath = "c:\\fake\\draft\\draft.exe";
+
+function draftFakePathConfig() : any {
+    return { 'vs-kubernetes.draft-path': draftFakePath };
+}
+
+suite("draft tests", () => {
+
+    suite("checkPresent method", () => {
+
+        suite("If draft is not on the path", () => {
+
+            test("...and configuration is not present, then checkPresent reports an error", async () => {
+                let errors : string[] = [];
+                const draft = draftCreateWithFakes({
+                    host: fakes.host({errors: errors})
+                });
+                const present = await draft.checkPresent();
+                assert.equal(false, present);
+                assert.equal(errors.length, 1);
+                textassert.startsWith('Could not find "draft" binary.', errors[0]);
+            });
+
+            test("...and configuration is present but file doesn't exist, then checkPresent reports an error", async () => {
+                let errors : string[] = [];
+                const draft = draftCreateWithFakes({
+                    host: fakes.host({errors: errors, configuration: draftFakePathConfig()})
+                });
+                const present = await draft.checkPresent();
+                assert.equal(false, present);
+                assert.equal(errors.length, 1);
+                textassert.startsWith('c:\\fake\\draft\\draft.exe does not exist!', errors[0]);
+            });
+
+            test("...and configuration is present and file exists, then checkPresent does not report any messages", async () => {
+                let errors = [];
+                let warnings : string[] = [];
+                let infos : string[] = [];
+                const draft = draftCreateWithFakes({
+                    host: fakes.host({errors: errors, warnings: warnings, infos: infos, configuration: draftFakePathConfig()}),
+                    fs: fakes.fs({existentPaths: [draftFakePath]})
+                });
+                await draft.checkPresent();
+                assert.equal(errors.length, 0);
+                assert.equal(warnings.length, 0);
+                assert.equal(infos.length, 0);
+            });
+
+            test("...and configuration is present and file exists, then checkPresent returns true", async () => {
+                const draft = draftCreateWithFakes({
+                    host: fakes.host({configuration: draftFakePathConfig()}),
+                    fs: fakes.fs({existentPaths: [draftFakePath]})
+                });
+                const present = await draft.checkPresent();
+                assert.equal(true, present);
+            });
+
+        });
+
+        suite("If draft is on the path", () => {
+
+            test("...no messages are reported on Windows", async () => {
+                let errors : string[] = [];
+                let warnings : string[] = [];
+                let infos : string[] = [];
+                const draft = draftCreateWithFakes({
+                    host: fakes.host({errors: errors, warnings: warnings, infos: infos}),
+                    shell: fakes.shell({recognisedCommands: [{command: 'where.exe draft.exe', code: 0, stdout: 'c:\\draft.exe'}]})
+                });
+                await draft.checkPresent();
+                assert.equal(errors.length, 0);
+                assert.equal(warnings.length, 0);
+                assert.equal(infos.length, 0);
+            });
+
+            test("...no messages are reported on Unix", async () => {
+                let errors : string[] = [];
+                let warnings : string[] = [];
+                let infos : string[] = [];
+                const draft = draftCreateWithFakes({
+                    host: fakes.host({errors: errors, warnings: warnings, infos: infos}),
+                    shell: fakes.shell({isWindows: false, isUnix: true, recognisedCommands: [{command: 'which draft', code: 0, stdout: '/usr/bin/draft'}]})
+                });
+                await draft.checkPresent();
+                assert.equal(errors.length, 0);
+                assert.equal(warnings.length, 0);
+                assert.equal(infos.length, 0);
+            });
+
+            test("...checkPresent returns true", async () => {
+                const draft = draftCreateWithFakes({
+                    shell: fakes.shell({recognisedCommands: [{command: 'where.exe draft.exe', code: 0, stdout: 'c:\\draft.exe'}]})
+                });
+                const present = await draft.checkPresent();
+                assert.equal(true, present);
+            });
+
+        });
+
+    });
+
+    suite("isFolderMapped method", () => {
+
+        test("If folder contains a draft.toml file and a .draftignore file, it is treated as already under draft control", () => {
+            const draft = draftCreateWithFakes({
+                fs: fakes.fs({
+                    existentPaths: [
+                        'c:\\dummy\\draft.toml',
+                        'c:\\dummy\\server.js',
+                        'c:\\dummy\\.draftignore',
+                        'c:\\dummy\\dockerfile'
+                    ]
+                })
+            });
+            const isMapped = draft.isFolderMapped('c:\\dummy');
+            assert.equal(isMapped, true);
+        });
+
+        test("If folder does not contain a draft.toml file, it is treated as not under draft control", () => {
+            const draft = draftCreateWithFakes({
+                fs: fakes.fs({
+                    existentPaths: [
+                        'c:\\dummy\\server.js',
+                        'c:\\dummy\\.draftignore',
+                        'c:\\dummy\\dockerfile'
+                    ]
+                })
+            });
+            const isMapped = draft.isFolderMapped('c:\\dummy');
+            assert.equal(isMapped, false);
+        });
+
+        test("If folder does not contain a .draftignore file, it is treated as not under draft control", () => {
+            const draft = draftCreateWithFakes({
+                fs: fakes.fs({
+                    existentPaths: [
+                        'c:\\dummy\\draft.toml',
+                        'c:\\dummy\\server.js',
+                        'c:\\somewhere\\.draftignore',
+                        'c:\\dummy\\dockerfile'
+                    ]
+                })
+            });
+            const isMapped = draft.isFolderMapped('c:\\dummy');
+            assert.equal(isMapped, false);
+        });
+
+    });
+
+    suite("packs method", () => {
+
+        // This failure mode doesn't need to be more informative, because in practice
+        // we check for presence before calling packs()
+        test("If draft is not present, packs() returns nothing", async() => {
+            const draft = draftCreateWithFakes({});
+            const packs = await draft.packs();
+            assert.equal(packs, undefined);
+        });
+
+        test("If draft home fails, packs() returns nothing", async() => {
+            const draft = draftCreateWithFakes({
+                shell: fakes.shell({recognisedCommands: [
+                    {command: 'where.exe draft.exe', code: 0, stdout: 'c:\\draft.exe'},
+                    {command: 'c:\\draft.exe home', code: 1, stderr: 'draft home failed'},
+                ]})
+            });
+            const packs = await draft.packs();
+            assert.equal(packs, undefined);
+        });
+
+        test("The packs subdirectory is scanned for entries", async() => {
+            let probedPath = '';
+            const draft = draftCreateWithFakes({
+                shell: fakes.shell({recognisedCommands: [
+                    {command: 'where.exe draft.exe', code: 0, stdout: 'c:\\draft.exe'},
+                    {command: 'draft home', code: 0, stdout: 'c:\\itowlson\\.draft\n'},
+                ]}),
+                fs: fakes.fs({
+                    onDirSync: (path) => { probedPath = path; return []; }
+                })
+            });
+            const packs = await draft.packs();
+            assert.equal(probedPath, 'c:\\itowlson\\.draft\\packs');
+        });
+
+        test("The entries in the packs subdirectory are returned", async() => {
+            const draft = draftCreateWithFakes({
+                shell: fakes.shell({recognisedCommands: [
+                    {command: 'where.exe draft.exe', code: 0, stdout: 'c:\\draft.exe'},
+                    {command: 'draft home', code: 0, stdout: 'c:\\itowlson\\.draft\n'},
+                ]}),
+                fs: fakes.fs({
+                    onDirSync: (path) => [ 'ponylang', 'haskell', 'befunge' ]
+                })
+            });
+            const packs = await draft.packs();
+            assert.equal(packs.length, 3);
+            assert.equal('ponylang', packs[0]);
+            assert.equal('haskell', packs[1]);
+            assert.equal('befunge', packs[2]);
+        });
+
+    });
+
+});

--- a/test/fakes.ts
+++ b/test/fakes.ts
@@ -1,5 +1,9 @@
 import { ShellResult } from '../src/shell';
 
+function nop(...args : any[]) {
+    return [];
+}
+
 export interface FakeHostSettings {
     errors? : string[];
     warnings? : string[];
@@ -9,6 +13,7 @@ export interface FakeHostSettings {
 
 export interface FakeFSSettings {
     existentPaths? : string[];
+    onDirSync? : (path: string) => string[];
 }
 
 export interface FakeCommand {
@@ -55,6 +60,7 @@ export function host(settings : FakeHostSettings = {}) : any {
 export function fs(settings : FakeFSSettings = {}) : any {
     return {
         existsSync: (path) => (settings.existentPaths || []).indexOf(path) >= 0,
+        dirSync: (path) => (settings.onDirSync || nop)(path),
     }
 }
 


### PR DESCRIPTION
The Draft workflow of automatic or simplified sync fits really nicely with an editing experience.  This feature adds support for initialising Draft in the folder that's open in VS Code, and deploying/watching it using `draft up`.  I'm not sure if this is the correct UI - perhaps when a folder is configured for watch in draft.toml, we should automatically start draft up in the background on load?  Open to discussion or iteration!